### PR TITLE
Improve storage hierarchy filtering to show content at same level and below

### DIFF
--- a/backend/app/api/movies.py
+++ b/backend/app/api/movies.py
@@ -15,6 +15,25 @@ from ..services.tmdb import get_tmdb_service, TMDBService
 
 router = APIRouter()
 
+# Upper bound for descendant lookups — prevents unbounded to_list() calls.
+_MAX_STORAGE_DESCENDANTS = 10_000
+
+
+async def _build_storage_filter(
+    db, storage_oid: ObjectId, include_descendants: bool
+) -> Dict[str, Any]:
+    """Return a MongoDB filter dict for storage_id, optionally spanning descendants.
+
+    When include_descendants is True the materialized-path index is used to
+    find all descendant nodes and the filter uses $in across the full subtree.
+    """
+    if include_descendants:
+        cursor = db.storage.find({"path": storage_oid}, {"_id": 1})
+        descendants = await cursor.to_list(length=_MAX_STORAGE_DESCENDANTS)
+        descendant_ids = [d["_id"] for d in descendants]
+        return {"storage_id": {"$in": [storage_oid] + descendant_ids}}
+    return {"storage_id": storage_oid}
+
 
 @router.post("/", response_model=MovieResponse, status_code=201)
 async def create_movie(
@@ -93,6 +112,9 @@ async def list_movies(
     skip: int = Query(0, ge=0, description="Number of movies to skip"),
     limit: int = Query(100, ge=1, le=1000, description="Number of movies to return"),
     storage_id: Optional[str] = Query(None, description="Filter by storage location"),
+    include_descendants: bool = Query(
+        False, description="Include movies from descendant storage locations"
+    ),
     format: Optional[str] = Query(None, description="Filter by media format"),
     genre: Optional[str] = Query(None, description="Filter by genre"),
     db=Depends(get_database),
@@ -106,9 +128,13 @@ async def list_movies(
 
     if storage_id:
         try:
-            filter_query["storage_id"] = ObjectId(storage_id)
+            storage_oid = ObjectId(storage_id)
         except Exception:
             raise HTTPException(status_code=400, detail="Invalid storage_id format")
+
+        filter_query.update(
+            await _build_storage_filter(db, storage_oid, include_descendants)
+        )
 
     if format:
         filter_query["format"] = format
@@ -148,6 +174,9 @@ async def search_movies(
     skip: int = Query(0, ge=0, description="Number of movies to skip"),
     limit: int = Query(100, ge=1, le=1000, description="Number of movies to return"),
     storage_id: Optional[str] = Query(None, description="Filter by storage location"),
+    include_descendants: bool = Query(
+        False, description="Include movies from descendant storage locations"
+    ),
     format: Optional[str] = Query(None, description="Filter by media format"),
     genre: Optional[str] = Query(None, description="Filter by genre"),
     db=Depends(get_database),
@@ -157,15 +186,24 @@ async def search_movies(
     Supports text search across movie titles and metadata.
     """
 
+    # Resolve storage filter (optionally including descendants)
+    storage_filter: Optional[Dict[str, Any]] = None
+    if storage_id:
+        try:
+            storage_oid = ObjectId(storage_id)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid storage_id format")
+
+        storage_filter = await _build_storage_filter(
+            db, storage_oid, include_descendants
+        )
+
     # Build filter query with text search
     filter_query: Dict[str, Any] = {"$text": {"$search": q}}
 
     # Add additional filters
-    if storage_id:
-        try:
-            filter_query["storage_id"] = ObjectId(storage_id)
-        except Exception:
-            raise HTTPException(status_code=400, detail="Invalid storage_id format")
+    if storage_filter:
+        filter_query.update(storage_filter)
 
     if format:
         filter_query["format"] = format
@@ -207,14 +245,9 @@ async def search_movies(
         try:
             filter_query: Dict[str, Any] = {"title": {"$regex": q, "$options": "i"}}
 
-            # Add additional filters
-            if storage_id:
-                try:
-                    filter_query["storage_id"] = ObjectId(storage_id)
-                except Exception:
-                    raise HTTPException(
-                        status_code=400, detail="Invalid storage_id format"
-                    )
+            # Add additional filters (reuse already-resolved storage_filter)
+            if storage_filter:
+                filter_query.update(storage_filter)
 
             if format:
                 filter_query["format"] = format

--- a/backend/tests/unit/api/test_movies_filter.py
+++ b/backend/tests/unit/api/test_movies_filter.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for the _build_storage_filter helper in movies API.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bson import ObjectId
+
+from app.api.movies import _build_storage_filter, _MAX_STORAGE_DESCENDANTS
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def storage_oid():
+    return ObjectId()
+
+
+def _make_db(descendants: list) -> MagicMock:
+    """Return a minimal mock db whose storage.find().to_list() returns *descendants*."""
+    cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=descendants)
+    db = MagicMock()
+    db.storage.find.return_value = cursor
+    return db
+
+
+# ── include_descendants=False ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_descendants_returns_exact_match(storage_oid):
+    """Without include_descendants, filter is a simple equality on storage_id."""
+    db = MagicMock()
+    result = await _build_storage_filter(db, storage_oid, include_descendants=False)
+
+    assert result == {"storage_id": storage_oid}
+    db.storage.find.assert_not_called()
+
+
+# ── include_descendants=True ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_with_descendants_includes_self_and_children(storage_oid):
+    """With include_descendants, result contains the node and all descendants."""
+    child1 = ObjectId()
+    child2 = ObjectId()
+    db = _make_db([{"_id": child1}, {"_id": child2}])
+
+    result = await _build_storage_filter(db, storage_oid, include_descendants=True)
+
+    assert result == {"storage_id": {"$in": [storage_oid, child1, child2]}}
+    db.storage.find.assert_called_once_with({"path": storage_oid}, {"_id": 1})
+    db.storage.find.return_value.to_list.assert_called_once_with(
+        length=_MAX_STORAGE_DESCENDANTS
+    )
+
+
+@pytest.mark.asyncio
+async def test_with_descendants_leaf_node_includes_only_self(storage_oid):
+    """A leaf node with no descendants returns $in with just itself."""
+    db = _make_db([])
+
+    result = await _build_storage_filter(db, storage_oid, include_descendants=True)
+
+    assert result == {"storage_id": {"$in": [storage_oid]}}
+
+
+@pytest.mark.asyncio
+async def test_descendant_query_uses_materialized_path(storage_oid):
+    """Descendant lookup queries the materialized path field, not parent_id."""
+    db = _make_db([])
+
+    await _build_storage_filter(db, storage_oid, include_descendants=True)
+
+    # Must query {"path": storage_oid} — the materialized path index
+    db.storage.find.assert_called_once_with({"path": storage_oid}, {"_id": 1})

--- a/frontend/src/lib/api/movies.ts
+++ b/frontend/src/lib/api/movies.ts
@@ -40,6 +40,7 @@ export interface MovieFilters {
 	skip?: number;
 	limit?: number;
 	storage_id?: string;
+	include_descendants?: boolean;
 	format?: string;
 	genre?: string;
 }
@@ -72,6 +73,7 @@ export async function listMovies(filters: MovieFilters = {}): Promise<Movie[]> {
 	if (filters.skip != null) params.set('skip', String(filters.skip));
 	if (filters.limit != null) params.set('limit', String(filters.limit));
 	if (filters.storage_id) params.set('storage_id', filters.storage_id);
+	if (filters.include_descendants) params.set('include_descendants', 'true');
 	if (filters.format) params.set('format', filters.format);
 	if (filters.genre) params.set('genre', filters.genre);
 	const qs = params.toString();
@@ -83,6 +85,7 @@ export async function searchMovies(q: string, filters: MovieFilters = {}): Promi
 	if (filters.skip != null) params.set('skip', String(filters.skip));
 	if (filters.limit != null) params.set('limit', String(filters.limit));
 	if (filters.storage_id) params.set('storage_id', filters.storage_id);
+	if (filters.include_descendants) params.set('include_descendants', 'true');
 	if (filters.format) params.set('format', filters.format);
 	if (filters.genre) params.set('genre', filters.genre);
 	return request<Movie[]>(`/api/movies/search?${params.toString()}`);

--- a/frontend/src/routes/(app)/movies/+page.svelte
+++ b/frontend/src/routes/(app)/movies/+page.svelte
@@ -16,13 +16,14 @@
 		type MovieFormat,
 		type TmdbMovie
 	} from '$lib/api/movies';
-	import { listStorage, type Storage } from '$lib/api/storage';
+	import { listStorage, buildTree, type Storage, type StorageNode } from '$lib/api/storage';
 	import { ApiError } from '$lib/api/client';
 	import { toast } from '$lib/stores/toast';
 
 	// ── State ────────────────────────────────────────────────────────────────
 	let movies = $state<Movie[]>([]);
 	let storageList = $state<Storage[]>([]);
+	let storageTree = $state<StorageNode[]>([]);
 	let loading = $state(true);
 	let error = $state('');
 
@@ -30,9 +31,32 @@
 	let filterFormat = $state('');
 	let filterStorage = $state('');
 	let filterGenre = $state('');
+	// When a storage filter is active, include movies from descendant nodes by default.
+	// This can be seeded from the URL param (e.g. when navigating from the storage page).
+	let filterIncludeDescendants = $state(true);
 
 	// Search
 	let searchQuery = $state($page.url.searchParams.get('q') ?? '');
+
+	// Flatten tree into depth-ordered list for dropdown (preserves hierarchy visually)
+	function flattenTree(nodes: StorageNode[], depth = 0): { storage: Storage; depth: number }[] {
+		const result: { storage: Storage; depth: number }[] = [];
+		for (const node of nodes) {
+			result.push({ storage: node, depth });
+			if (node.children.length > 0) {
+				result.push(...flattenTree(node.children, depth + 1));
+			}
+		}
+		return result;
+	}
+
+	// Reactive flattened storage list ordered by hierarchy for the dropdown
+	let storageOptions = $derived(flattenTree(storageTree));
+
+	// Whether the currently selected storage has children (i.e., descendants exist)
+	let selectedStorageHasChildren = $derived(
+		filterStorage ? storageList.some((s) => s.path.includes(filterStorage)) : false
+	);
 
 	// Modal state
 	let showModal = $state(false);
@@ -60,6 +84,17 @@
 
 	// ── Lifecycle ────────────────────────────────────────────────────────────
 	onMount(async () => {
+		// Restore storage filter from URL (e.g. when arriving from the storage page).
+		// include_descendants defaults to true; the storage page passes 'false' explicitly
+		// when the user had the toggle off.
+		const urlStorageId = $page.url.searchParams.get('storage_id') ?? '';
+		const urlDescendantsParam = $page.url.searchParams.get('include_descendants');
+		if (urlStorageId) {
+			filterStorage = urlStorageId;
+			if (urlDescendantsParam !== null) {
+				filterIncludeDescendants = urlDescendantsParam === 'true';
+			}
+		}
 		await Promise.all([loadMovies(), loadStorage()]);
 	});
 
@@ -80,6 +115,7 @@
 			const filters = {
 				format: filterFormat || undefined,
 				storage_id: filterStorage || undefined,
+				include_descendants: filterStorage ? filterIncludeDescendants : undefined,
 				genre: filterGenre || undefined,
 				limit: 200
 			};
@@ -98,6 +134,7 @@
 	async function loadStorage() {
 		try {
 			storageList = await listStorage({ limit: 500 });
+			storageTree = buildTree(storageList);
 		} catch {
 			// Non-critical
 		}
@@ -299,16 +336,23 @@
 			{/each}
 		</select>
 
-		<select
-			bind:value={filterStorage}
-			onchange={applyFilters}
-			class="text-sm px-3 py-1.5 rounded-lg border border-surface-200 dark:border-surface-600 bg-surface-50 dark:bg-surface-700 text-surface-700 dark:text-surface-300"
-		>
-			<option value="">All Storage</option>
-			{#each storageList as s}
-				<option value={s.id}>{s.name}</option>
-			{/each}
-		</select>
+		<div class="flex flex-col gap-1">
+			<select
+				bind:value={filterStorage}
+				onchange={applyFilters}
+				class="text-sm px-3 py-1.5 rounded-lg border border-surface-200 dark:border-surface-600 bg-surface-50 dark:bg-surface-700 text-surface-700 dark:text-surface-300"
+			>
+				<option value="">All Storage</option>
+				{#each storageOptions as { storage, depth }}
+					<option value={storage.id}>
+						{#if depth > 0}{' '.repeat(depth * 2)}└ {/if}{storage.name}
+					</option>
+				{/each}
+			</select>
+			{#if filterStorage && selectedStorageHasChildren && filterIncludeDescendants}
+				<span class="text-xs text-primary-500 px-1">includes sub-locations</span>
+			{/if}
+		</div>
 
 		<input
 			type="text"

--- a/frontend/src/routes/(app)/storage/+page.svelte
+++ b/frontend/src/routes/(app)/storage/+page.svelte
@@ -24,6 +24,7 @@
 	let selectedNode = $state<Storage | null>(null);
 	let selectedMovies = $state<Movie[]>([]);
 	let moviesLoading = $state(false);
+	let includeDescendants = $state(true);
 
 	// Modal
 	let showModal = $state(false);
@@ -67,15 +68,34 @@
 
 	async function selectNode(node: Storage) {
 		selectedNode = node;
+		await reloadMovies();
+	}
+
+	async function reloadMovies() {
+		if (!selectedNode) return;
 		moviesLoading = true;
 		selectedMovies = [];
 		try {
-			selectedMovies = await listMovies({ storage_id: node.id, limit: 200 });
+			selectedMovies = await listMovies({
+				storage_id: selectedNode.id,
+				include_descendants: includeDescendants,
+				limit: 200
+			});
 		} catch {
 			selectedMovies = [];
 		} finally {
 			moviesLoading = false;
 		}
+	}
+
+	// Recompute: does the selected node have any descendants?
+	let selectedHasChildren = $derived(
+		selectedNode ? storageList.some((s) => s.path.includes(selectedNode!.id)) : false
+	);
+
+	// For a movie, find its direct storage name (may differ from selectedNode when including descendants)
+	function movieStorageName(storageId: string): string {
+		return storageList.find((s) => s.id === storageId)?.name ?? '';
 	}
 
 	// ── Modal helpers ─────────────────────────────────────────────────────────
@@ -341,14 +361,27 @@
 				<!-- Movies in this storage -->
 				<div>
 					<div class="flex items-center justify-between mb-3">
-						<h3 class="font-semibold text-surface-800 dark:text-surface-200">
-							Movies
-							{#if selectedMovies.length > 0}
-								<span class="ml-1 text-sm font-normal text-surface-400">({selectedMovies.length})</span>
+						<div class="flex items-center gap-3 flex-wrap">
+							<h3 class="font-semibold text-surface-800 dark:text-surface-200">
+								Movies
+								{#if selectedMovies.length > 0}
+									<span class="ml-1 text-sm font-normal text-surface-400">({selectedMovies.length})</span>
+								{/if}
+							</h3>
+							{#if selectedHasChildren}
+								<label class="flex items-center gap-1.5 cursor-pointer select-none">
+									<input
+										type="checkbox"
+										bind:checked={includeDescendants}
+										onchange={reloadMovies}
+										class="w-3.5 h-3.5 rounded accent-primary-500"
+									/>
+									<span class="text-xs text-surface-500">include sub-locations</span>
+								</label>
 							{/if}
-						</h3>
+						</div>
 						<a
-							href="/movies?storage_id={selectedNode.id}"
+							href="/movies?storage_id={selectedNode.id}&include_descendants={includeDescendants && selectedHasChildren ? 'true' : 'false'}"
 							class="text-xs text-primary-500 hover:underline"
 						>
 							View all →
@@ -361,7 +394,11 @@
 						</div>
 					{:else if selectedMovies.length === 0}
 						<div class="text-center py-8 border border-dashed border-surface-200 dark:border-surface-700 rounded-xl text-surface-400">
-							<p class="text-sm">No movies in this location</p>
+							<p class="text-sm">
+								{includeDescendants && selectedHasChildren
+									? 'No movies in this location or its sub-locations'
+									: 'No movies directly in this location'}
+							</p>
 						</div>
 					{:else}
 						<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
@@ -377,6 +414,11 @@
 									<div class="p-2">
 										<p class="text-xs font-semibold text-surface-900 dark:text-surface-50 line-clamp-2 leading-tight">{movie.title}</p>
 										<p class="text-xs text-surface-400">{movie.year} · {movie.format}</p>
+										{#if includeDescendants && movie.storage_id !== selectedNode.id}
+											<p class="text-xs text-surface-400 mt-0.5 truncate" title={movieStorageName(movie.storage_id)}>
+												📦 {movieStorageName(movie.storage_id)}
+											</p>
+										{/if}
 									</div>
 								</div>
 							{/each}


### PR DESCRIPTION
## Summary

- **Backend**: Add `include_descendants` query param to `GET /movies/` and `GET /movies/search`. When enabled with a `storage_id`, uses the materialized path to find all descendant storage nodes and filters movies with `$in` across the full subtree.

- **Frontend API** (`movies.ts`): Expose `include_descendants` in `MovieFilters` and pass it as a query parameter in `listMovies`/`searchMovies`.

- **Storage page**: `selectNode` now fetches movies with `include_descendants=true` by default. A 'include sub-locations' checkbox lets users toggle to direct-only. Movies sourced from descendant nodes show a storage name badge so users can see which bin/shelf each title lives in.

- **Movies page**: Storage filter dropdown renders hierarchy in depth order with indentation so parent/child relationships are visible at a glance. Selecting any storage automatically includes descendants, and an 'includes sub-locations' label appears when the chosen location has children. URL param `storage_id` and `include_descendants` from the storage page 'View all' link are both honoured on mount.

## Changes from review

After rebasing onto `fresh-start` the following issues were addressed:

- **Extracted `_build_storage_filter` helper** (`backend/app/api/movies.py`): the identical descendant-lookup block that appeared in both `list_movies` and `search_movies` is now a single async helper. Added `_MAX_STORAGE_DESCENDANTS = 10_000` constant to document the `to_list` cap.

- **Added unit tests** (`backend/tests/unit/api/test_movies_filter.py`): 4 tests using `AsyncMock` covering exact-match filter, descendant expansion, leaf-node edge case, and correct materialized-path query. Unit test count: 36 → 40.

- **`selectedHasChildren` converted to `$derived`** (`storage/+page.svelte`): was a plain function called reactively in the template; now a proper Svelte 5 derived value, consistent with the movies page pattern.

- **`include_descendants` URL param honoured** (`movies/+page.svelte`): `loadMovies` was hardcoding `include_descendants: true` whenever a storage filter was active, ignoring the param passed from the storage page. Now reads it from `filterIncludeDescendants` state (defaults to `true`), seeded from the URL on mount. The 'includes sub-locations' badge is also conditional on the state variable.

## Test plan

- [x] Backend lint (flake8 + black) — passing
- [x] Backend unit tests (40 tests) — passing
- [x] Frontend type check + build — passing
- [x] Docker image build — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)