### PR TITLE
fix: allow clearing all genres when editing a movie

### DIFF
--- a/backend/tests/integration/api/test_movies_api.py
+++ b/backend/tests/integration/api/test_movies_api.py
@@ -311,6 +311,27 @@ async def test_update_movie_success(client, test_db, sample_storage):
     assert data["format"] == "DVD"  # Unchanged field
 
 
+async def test_update_movie_clear_genres(client, test_db, sample_storage):
+    """Test that updating a movie with an empty genre list clears all genres."""
+    # Create a movie with genres
+    movie_data = {
+        "title": "Test Movie",
+        "year": 2020,
+        "format": "DVD",
+        "storage_id": ObjectId(sample_storage),
+        "genre": ["Action", "Thriller"]
+    }
+    result = await test_db.movies.insert_one(movie_data)
+    movie_id = str(result.inserted_id)
+
+    # Clear all genres by sending an empty list
+    response = await client.put(f"/api/movies/{movie_id}", json={"genre": []})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["genre"] == [] or data["genre"] is None
+
+
 async def test_update_movie_storage_location(client, test_db):
     """Test updating movie storage location."""
     # Create two storage locations

--- a/frontend/src/routes/(app)/movies/+page.svelte
+++ b/frontend/src/routes/(app)/movies/+page.svelte
@@ -238,7 +238,7 @@
 				format: formFormat,
 				storage_id: formStorageId,
 				tmdb_id: formTmdbId,
-				genre: formGenre ? formGenre.split(',').map((g) => g.trim()).filter(Boolean) : undefined,
+				genre: formGenre ? formGenre.split(',').map((g) => g.trim()).filter(Boolean) : [],
 				runtime: formRuntime !== '' ? Number(formRuntime) : undefined,
 				cover_image: formCoverImage.trim() || undefined
 			};


### PR DESCRIPTION
When formGenre is empty (user clears the field), send an empty array [] instead of undefined so the backend's exclude_unset serialization includes the field and the MongoDB update actually clears the genres.

Previously, an empty string was falsy so the ternary returned undefined, which JSON.stringify omitted, causing the backend to skip updating the genre field entirely.

Also adds a backend integration test verifying that PUT /api/movies/:id with genre:[] successfully clears genres.

Fixes #8